### PR TITLE
tagging image to docker engine

### DIFF
--- a/docker_kernel/kernel.py
+++ b/docker_kernel/kernel.py
@@ -28,7 +28,6 @@ class DockerKernel(Kernel):
         self._api = docker.APIClient(base_url='unix://var/run/docker.sock')
         self._sha1: str | None = None
         self._payload = []
-        self._kernel = self
 
     
     @property
@@ -174,5 +173,5 @@ class DockerKernel(Kernel):
         """
 
         self._api.tag(image, name, tag)
-        self._kernel.send_response(f"Image {image} is tagged with: {name}:{tag if tag is not None else 'latest'}")
+        self.send_response(f"Image {image} is tagged with: {name}:{tag if tag is not None else 'latest'}")
 

--- a/docker_kernel/kernel.py
+++ b/docker_kernel/kernel.py
@@ -28,6 +28,7 @@ class DockerKernel(Kernel):
         self._api = docker.APIClient(base_url='unix://var/run/docker.sock')
         self._sha1: str | None = None
         self._payload = []
+        self._kernel = self
 
     
     @property
@@ -172,4 +173,6 @@ class DockerKernel(Kernel):
         None
         """
 
-        docker.client.from_env().images.get(image).tag(name,tag)
+        self._api.tag(image, name, tag)
+        self._kernel.send_response(f"Image {image} is tagged with: {name}:{tag if tag is not None else 'latest'}")
+

--- a/docker_kernel/kernel.py
+++ b/docker_kernel/kernel.py
@@ -27,7 +27,6 @@ class DockerKernel(Kernel):
         super().__init__(**kwargs)
         self._api = docker.APIClient(base_url='unix://var/run/docker.sock')
         self._sha1: str | None = None
-        self._tags: dict[str, dict[str, str]] = {}
         self._payload = []
 
     
@@ -156,25 +155,21 @@ class DockerKernel(Kernel):
             "text": text,
             "replace": replace,
         }]
-                    
-    def tag_image(self, image_id: str, name: str, tag: str|None=None):
+
+    def tag_image(self, image: str, name: str, tag: str|None=None):
         """ Tag an image.
         Parameters
         ----------
-        image_id: str
-            Id of image to be saved.
+        image: str
+            Id or name of the image to be tagged.
         name: str
             Image name to be assigned.
         tag: str, optional
             Typically a specific version or variant of an image.
-        
+
         Return
         ------
         None
         """
-        tag = self.default_tag if tag is None else tag
 
-        if name not in self._tags:
-            self._tags[name] = {}
-
-        self._tags[name][tag] = image_id
+        docker.client.from_env().images.get(image).tag(name,tag)

--- a/docker_kernel/magics/tag.py
+++ b/docker_kernel/magics/tag.py
@@ -49,13 +49,9 @@ class Tag(Magic):
             # If no colon is provided the default tag is used
             if ":" not in target_image:
                 name = target_image
-                tag = 'latest'
+                tag = None
             else:
                 raise MagicError("Error parsing arguments:\n" + 
                                 f"\t\"{source_image}\" is not valid: invalid reference format")
 
-        if source_image is None:
-            raise MagicError("No image specified")
-
         self._kernel.tag_image(source_image, name, tag=tag)
-        self._kernel.send_response(f"Image {source_image} is tagged with: {name}:{tag}")

--- a/docker_kernel/magics/tag.py
+++ b/docker_kernel/magics/tag.py
@@ -1,5 +1,7 @@
 from typing import Callable
 
+import docker.client
+
 from .magic import Magic
 from .helper.errors import MagicError
 from.helper.types import FlagDict
@@ -11,7 +13,7 @@ class Tag(Magic):
 
     @staticmethod
     def REQUIRED_ARGS() -> tuple[list[str], int]:
-        return (["target"], 1)
+        return (["source image","target image"], 2)
         
     @staticmethod
     def ARGS_RULES() -> dict[int, list[tuple[Callable[[str], bool], str]]]:
@@ -35,24 +37,25 @@ class Tag(Magic):
         }
     
     def _execute_magic(self) -> None:
-        target = self._args[0]
+        """
+        usage:
+        %tag source_image[:tag] target_image[:tag]
+        """
+        source_image = self._args[0]
+        target_image = self._args[1]
         try:
-            name, tag = target.split(":")
+            name, tag = target_image.split(":")
         except ValueError as e:
             # If no colon is provided the default tag is used
-            if ":" not in target:
-                name = target
-                tag = None
+            if ":" not in target_image:
+                name = target_image
+                tag = 'latest'
             else:
                 raise MagicError("Error parsing arguments:\n" + 
-                                f"\t\"{target}\" is not valid: invalid reference format")
+                                f"\t\"{source_image}\" is not valid: invalid reference format")
 
-        image_id = self._get_default_flag("image", "i", self._kernel._sha1)
-        if image_id is None:
+        if source_image is None:
             raise MagicError("No image specified")
 
-        self._kernel.tag_image(image_id, name, tag=tag)
-
-        image_str = image_id.removeprefix("sha256:")
-        image_str = f"{image_str[:10]}..." if len(image_str) >= 10 else image_str
-        self._kernel.send_response(f"Image {image_str} tagged")
+        self._kernel.tag_image(source_image, name, tag=tag)
+        self._kernel.send_response(f"Image {source_image} is tagged with: {name}:{tag}")


### PR DESCRIPTION
instead of saving the tags in local storage, we tag the image to the docker engine just like the docker command "**[docker tag](https://docs.docker.com/engine/reference/commandline/tag/)**" does:
$ docker tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]

e.g.
$ docker tag 0e5574283393 fedora/httpd:version1.0
