### PR TITLE
Error handling

### DIFF
--- a/docker_kernel/kernel.py
+++ b/docker_kernel/kernel.py
@@ -271,8 +271,10 @@ class DockerKernel(Kernel):
         except APIError as e:
             if e.explanation is not None:
                 self.send_response(str(e.explanation))
+                return
             else:
                 self.send_response(str(e))
+                return
         self._save_build_stage(code, self._sha1)
 
     def _save_build_stage(self, code, image_id):

--- a/docker_kernel/kernel.py
+++ b/docker_kernel/kernel.py
@@ -271,10 +271,9 @@ class DockerKernel(Kernel):
         except APIError as e:
             if e.explanation is not None:
                 self.send_response(str(e.explanation))
-                return
             else:
                 self.send_response(str(e))
-                return
+            return
         self._save_build_stage(code, self._sha1)
 
     def _save_build_stage(self, code, image_id):


### PR DESCRIPTION
Basically, this prevents errors that previously occurred, when an `APIError` was generated and, therefore, no image_id was generated by Docker. This could lead to a `KeyError` in `save_build_stage`, when no previous `build_stage` existed, and the code didn't begin with "from", "arg" or "#".

Thanks,
Marco